### PR TITLE
Remove CodeTag from expression

### DIFF
--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -20,7 +20,6 @@ expression {
   ChainedIdentifier |
   Comparison |
   Operator |
-  CodeTag |
   Math |
   Array |
   basicType |


### PR DESCRIPTION
`{{ formatDate('x') }}` gets highlighted as `<for><matDate>` whereby `for` and `matDate` are different colours.

It shouldn't be possible to use a `CodeTag` within an expression because `CodeBlock { "{%" CodeTag? !top expression* "%}" }` already checks for it.